### PR TITLE
Added direct pip install instructions to Readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,15 @@ devtools::install_github("BlakeRMills/MetBrewer")
 ```
 
 ### Python
-Install the package under the `Python/` directory directly:
+Install the package via pip without manually downloading the repository:
+```
+pip install git+https://github.com/BlakeRMills/MetBrewer.git#subdirectory=Python
+```
+Or download the repository manually and install under the `Python/` directory directly:
 ```
 python setup.py install
 ```
-or via pip:
+or via pip from the `Python/` directory:
 ```
 pip install .
 ```


### PR DESCRIPTION
Running
`pip install git+https://github.com/BlakeRMills/MetBrewer.git#subdirectory=Python`
directly installs the Python package without any further manual downloading.